### PR TITLE
Create order details page and routes

### DIFF
--- a/src/pages/Orders/OneOrderPage.tsx
+++ b/src/pages/Orders/OneOrderPage.tsx
@@ -1,0 +1,150 @@
+import {useEffect, useMemo} from "react";
+import {Link, useParams} from "react-router-dom";
+import {useSocket} from "../../context/SocketContext.tsx";
+import {
+    DeliveryType,
+    IOrder,
+    OrderStatus,
+    PaymentMethod,
+} from "../../store/interfaces/order.interface.ts";
+import styles from "./orders.module.sass";
+
+const STATUS_LABEL: Record<OrderStatus, string> = {
+    [OrderStatus.PENDING]: "В ожидании",
+    [OrderStatus.PROCESSING]: "В обработке",
+    [OrderStatus.CONFIRMED]: "Подтвержден",
+    [OrderStatus.SHIPPED]: "Отправлен",
+    [OrderStatus.DELIVERED]: "Доставлен",
+    [OrderStatus.CANCELLED]: "Отменен",
+    [OrderStatus.REFUNDED]: "Возвращен",
+};
+
+const DELIVERY_LABEL: Record<DeliveryType, string> = {
+    [DeliveryType.PICKUP]: "Самовывоз",
+    [DeliveryType.KRASNODAR]: "Доставка по Краснодару",
+    [DeliveryType.RUSSIA]: "Доставка по России",
+};
+
+const PAYMENT_LABEL: Record<PaymentMethod, string> = {
+    [PaymentMethod.CARD]: "Картой",
+    [PaymentMethod.CASH]: "Наличные",
+    [PaymentMethod.SBP]: "СБП",
+    [PaymentMethod.INVOICE]: "По счету",
+    [PaymentMethod.PAYINSHOP]: "Оплата в магазине",
+};
+
+const formatCurrency = (value: number) =>
+    new Intl.NumberFormat("ru-RU", {
+        style: "currency",
+        currency: "RUB",
+        maximumFractionDigits: 0,
+    }).format(value);
+
+export const OneOrderPage = () => {
+    const {orders, getOrders} = useSocket();
+    const {orderId} = useParams();
+
+    useEffect(() => {
+        if (!orders || orders.length === 0) getOrders();
+    }, []);
+
+    const order: IOrder | undefined = useMemo(() => {
+        if (!orderId) return undefined;
+        const byId = orders.find((o: IOrder) => o._id === orderId);
+        if (byId) return byId;
+        if (orderId.startsWith("ORD-")) {
+            return orders.find((o: IOrder) => o.orderNumber === orderId);
+        }
+        return undefined;
+    }, [orders, orderId]);
+
+    if (!order) {
+        return (
+            <div className="main__container">
+                <div className="mb-10">
+                    <Link to="/orders">← Назад к списку заказов</Link>
+                </div>
+                <h1 className={styles.title}>Заказ</h1>
+                <p>Загрузка или заказ не найден.</p>
+            </div>
+        );
+    }
+
+    return (
+        <div className="main__container">
+            <div className="mb-10">
+                <Link to="/orders">← Назад к списку заказов</Link>
+            </div>
+
+            <h1 className={styles.title}>Заказ {order.orderNumber}</h1>
+
+            <div className={styles.orderDetails}>
+                <section className="mb-10">
+                    <h2>Информация</h2>
+                    <p><b>Статус:</b> {STATUS_LABEL[order.status]}</p>
+                    <p><b>Создан:</b> {new Date(order.createdAt).toLocaleString()}</p>
+                    <p><b>Обновлен:</b> {new Date(order.updatedAt).toLocaleString()}</p>
+                    {order.trackingNumber && (
+                        <p><b>Трек-номер:</b> {order.trackingNumber}</p>
+                    )}
+                </section>
+
+                <section className="mb-10">
+                    <h2>Покупатель</h2>
+                    <p><b>ФИО:</b> {order.owner.fullName}</p>
+                    <p><b>Телефон:</b> {order.deliveryInfo.phone}</p>
+                </section>
+
+                <section className="mb-10">
+                    <h2>Доставка</h2>
+                    <p><b>Тип:</b> {DELIVERY_LABEL[order.deliveryType]}</p>
+                    <p><b>Город:</b> {order.deliveryInfo.city}</p>
+                    <p><b>Адрес:</b> {order.deliveryInfo.address}</p>
+                    {order.deliveryInfo.postalCode && (
+                        <p><b>Индекс:</b> {order.deliveryInfo.postalCode}</p>
+                    )}
+                    {order.deliveryInfo.comment && (
+                        <p><b>Комментарий:</b> {order.deliveryInfo.comment}</p>
+                    )}
+                </section>
+
+                <section className="mb-10">
+                    <h2>Оплата</h2>
+                    <p><b>Способ:</b> {PAYMENT_LABEL[order.paymentMethod]}</p>
+                    <p><b>Статус оплаты:</b> {order.paymentStatus ? "Оплачен" : "Не оплачен"}</p>
+                    {order.invoiceUrl && (
+                        <p>
+                            <a href={order.invoiceUrl} target="_blank" rel="noreferrer">Открыть счет/накладную</a>
+                        </p>
+                    )}
+                    {order.documentUrl && (
+                        <p>
+                            <a href={order.documentUrl} target="_blank" rel="noreferrer">Скачать документ</a>
+                        </p>
+                    )}
+                </section>
+
+                <section className="mb-10">
+                    <h2>Состав заказа</h2>
+                    <ul>
+                        {order.items.map((it, i) => (
+                            <li key={i}>
+                                {it.product} × {it.quantity} — {formatCurrency(it.price)}
+                            </li>
+                        ))}
+                    </ul>
+                </section>
+
+                <section className="mb-10">
+                    <h2>Итоги</h2>
+                    <p><b>Сумма товаров:</b> {formatCurrency(order.totalAmount)}</p>
+                    <p><b>Скидка:</b> {formatCurrency(order.discountAmount)}</p>
+                    <p><b>Доставка:</b> {formatCurrency(order.deliveryCost)}</p>
+                    <p><b>Итого:</b> {formatCurrency(order.finalAmount)}</p>
+                </section>
+            </div>
+        </div>
+    );
+};
+
+export default OneOrderPage;

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -21,6 +21,7 @@ import {UsersPage} from "../pages/users/UsersPage.tsx";
 import {Chat} from "../pages/Chat/Chat.tsx";
 import CheckoutPage from "../pages/Cart/CheckoutPage";
 import {OrdersPage} from "../pages/Orders/OrdersPage.tsx";
+import {OneOrderPage} from "../pages/Orders/OneOrderPage.tsx";
 // import CodeVerification from "../pages/Auth/CodeVerification.tsx";
 
 const router = createBrowserRouter([
@@ -43,6 +44,7 @@ const router = createBrowserRouter([
             {path: "/categories/:category-slug/:product-slug", element: <OneProductPage/>},
             {path: "/lk/:id", element: <Lk/>},
             {path: "/orders", element: <OrdersPage/>},
+            {path: "/orders/:orderId", element: <OneOrderPage/>},
             {path: "/profile", element: <Profile/>},
             {path: "/solution", element: <Solution/>},
             {path: "/solution/:solution-slug", element: <OneSolution/>},

--- a/src/types/style-modules.d.ts
+++ b/src/types/style-modules.d.ts
@@ -1,0 +1,18 @@
+declare module "*.module.css" {
+    const classes: { readonly [key: string]: string };
+    export default classes;
+}
+
+declare module "*.module.scss" {
+    const classes: { readonly [key: string]: string };
+    export default classes;
+}
+
+declare module "*.module.sass" {
+    const classes: { readonly [key: string]: string };
+    export default classes;
+}
+
+declare module "*.css";
+declare module "*.scss";
+declare module "*.sass";

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -14,7 +14,7 @@
     "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",
-    "types": ["tailwindcss"],
+    "types": ["vite/client", "react", "react-dom", "tailwindcss"],
 
     /* Linting */
     "strict": true,


### PR DESCRIPTION
Add `OneOrderPage` to display detailed order information, accessible via the `/orders/:orderId` route.

---
<a href="https://cursor.com/background-agent?bcId=bc-c79d9e60-3dce-44b5-a590-85573ba52fc4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c79d9e60-3dce-44b5-a590-85573ba52fc4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

